### PR TITLE
Feature/version 0.2.4

### DIFF
--- a/api/radio_browser.py
+++ b/api/radio_browser.py
@@ -1,8 +1,10 @@
+import time
 import requests
 from PyQt6.QtCore import QRunnable, QObject, pyqtSignal, QThreadPool
 
 BASE_URL = "https://de1.api.radio-browser.info/json"
 HEADERS = {"User-Agent": "dyedfox-radio/1.0"}
+_RETRY_DELAYS = [1, 3]
 
 
 class _Signals(QObject):
@@ -19,12 +21,20 @@ class _ApiWorker(QRunnable):
         self.signals = _Signals()
 
     def run(self):
-        try:
-            resp = requests.get(self.url, params=self.params, headers=HEADERS, timeout=10)
-            resp.raise_for_status()
-            self.signals.result.emit(resp.json())
-        except Exception as e:
-            self.signals.error.emit(str(e))
+        last_error = "Empty response"
+        for delay in (0, *_RETRY_DELAYS):
+            if delay:
+                time.sleep(delay)
+            try:
+                resp = requests.get(self.url, params=self.params, headers=HEADERS, timeout=10)
+                resp.raise_for_status()
+                data = resp.json()
+                if data:
+                    self.signals.result.emit(data)
+                    return
+            except Exception as e:
+                last_error = str(e)
+        self.signals.error.emit(last_error)
 
 
 class _PostApiWorker(QRunnable):
@@ -36,12 +46,20 @@ class _PostApiWorker(QRunnable):
         self.signals = _Signals()
 
     def run(self):
-        try:
-            resp = requests.post(self.url, data=self.data, headers=HEADERS, timeout=10)
-            resp.raise_for_status()
-            self.signals.result.emit(resp.json())
-        except Exception as e:
-            self.signals.error.emit(str(e))
+        last_error = "Empty response"
+        for delay in (0, *_RETRY_DELAYS):
+            if delay:
+                time.sleep(delay)
+            try:
+                resp = requests.post(self.url, data=self.data, headers=HEADERS, timeout=10)
+                resp.raise_for_status()
+                data = resp.json()
+                if data:
+                    self.signals.result.emit(data)
+                    return
+            except Exception as e:
+                last_error = str(e)
+        self.signals.error.emit(last_error)
 
 
 class RadioBrowserClient:

--- a/data/custom_stations.py
+++ b/data/custom_stations.py
@@ -2,7 +2,7 @@ import json
 import uuid
 from pathlib import Path
 
-_CONFIG = Path.home() / ".config" / "radiox"
+_CONFIG = Path.home() / ".config" / "dyedfox-radio"
 _CUSTOM_FILE = _CONFIG / "custom_stations.json"
 
 
@@ -55,4 +55,4 @@ class CustomStationsManager:
         try:
             _CUSTOM_FILE.write_text(json.dumps(self._stations, indent=2))
         except Exception as e:
-            print(f"radiox: failed to save custom stations: {e}", flush=True)
+            print(f"dyedfox-radio: failed to save custom stations: {e}", flush=True)

--- a/data/favourites.py
+++ b/data/favourites.py
@@ -1,7 +1,7 @@
 import json
 from pathlib import Path
 
-_CONFIG = Path.home() / ".config" / "radiox"
+_CONFIG = Path.home() / ".config" / "dyedfox-radio"
 _FAV_FILE = _CONFIG / "favourites.json"
 _RECENT_FILE = _CONFIG / "recent.json"
 
@@ -36,7 +36,7 @@ class FavouritesManager:
         try:
             path.write_text(json.dumps(data, indent=2))
         except Exception as e:
-            print(f"radiox: failed to save {path}: {e}", flush=True)
+            print(f"dyedfox-radio: failed to save {path}: {e}", flush=True)
 
 
 class RecentManager:
@@ -72,4 +72,4 @@ class RecentManager:
         try:
             _RECENT_FILE.write_text(json.dumps(self._uuids, indent=2))
         except Exception as e:
-            print(f"radiox: failed to save recent: {e}", flush=True)
+            print(f"dyedfox-radio: failed to save recent: {e}", flush=True)

--- a/data/settings.py
+++ b/data/settings.py
@@ -1,7 +1,7 @@
 import json
 from pathlib import Path
 
-_CONFIG = Path.home() / ".config" / "radiox"
+_CONFIG = Path.home() / ".config" / "dyedfox-radio"
 _FILE = _CONFIG / "settings.json"
 
 DEFAULTS: dict = {
@@ -33,4 +33,4 @@ class Settings:
         try:
             _FILE.write_text(json.dumps(self._data, indent=2))
         except Exception as e:
-            print(f"radiox: failed to save settings: {e}", flush=True)
+            print(f"dyedfox-radio: failed to save settings: {e}", flush=True)

--- a/main.py
+++ b/main.py
@@ -42,7 +42,15 @@ def _try_raise_existing() -> bool:
     return False
 
 
+def _migrate_config():
+    old = Path.home() / ".config" / "radiox"
+    new = Path.home() / ".config" / "dyedfox-radio"
+    if old.exists() and not new.exists():
+        old.rename(new)
+
+
 def main():
+    _migrate_config()
     Gst.init(None)
 
     # Load settings before QApplication so we can suppress the KDE startup

--- a/player/mpris.py
+++ b/player/mpris.py
@@ -32,7 +32,7 @@ if _DBUS_OK:
             self._bridge = bridge
             self._backend = backend
             self._metadata = dbus.Dictionary(
-                {"mpris:trackid": dbus.ObjectPath("/org/radiox/track/0"),
+                {"mpris:trackid": dbus.ObjectPath("/org/dyedfoxradio/track/0"),
                  "xesam:title": dbus.String(""),
                  "xesam:artist": dbus.Array([""], signature="s")},
                 signature="sv",
@@ -74,7 +74,7 @@ if _DBUS_OK:
 
         def push_metadata(self, title: str, station: str, art_url: str):
             self._metadata = dbus.Dictionary(
-                {"mpris:trackid": dbus.ObjectPath("/org/radiox/track/1"),
+                {"mpris:trackid": dbus.ObjectPath("/org/dyedfoxradio/track/1"),
                  "xesam:title": dbus.String(title),
                  "xesam:artist": dbus.Array([station], signature="s"),
                  "mpris:artUrl": dbus.String(art_url)},
@@ -154,7 +154,7 @@ class MprisPlayer:
 
 def setup_mpris(backend, window) -> "MprisPlayer | None":
     if not _DBUS_OK:
-        print("radiox: python-dbus not available, MPRIS disabled", flush=True)
+        print("dyedfox-radio: python-dbus not available, MPRIS disabled", flush=True)
         return None
     try:
         bus = dbus.SessionBus()
@@ -184,5 +184,5 @@ def setup_mpris(backend, window) -> "MprisPlayer | None":
 
         return MprisPlayer(obj, poller, bridge)
     except Exception as e:
-        print(f"radiox: MPRIS setup failed: {e}", flush=True)
+        print(f"dyedfox-radio: MPRIS setup failed: {e}", flush=True)
         return None

--- a/ui/about_dialog.py
+++ b/ui/about_dialog.py
@@ -31,7 +31,7 @@ class AboutDialog(QDialog):
         name.setFont(f)
         layout.addWidget(name)
 
-        version = QLabel("Version 0.2.3")
+        version = QLabel("Version 0.2.4")
         version.setAlignment(Qt.AlignmentFlag.AlignCenter)
         version.setEnabled(False)
         layout.addWidget(version)

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -407,6 +407,9 @@ class MainWindow(QMainWindow):
             self._info_panel.set_favourite(is_fav)
 
     def _on_search(self, text: str):
+        if not text:
+            self._switch_view(self._current_view)
+            return
         words = text.lower().split()
         if not words:
             return

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -227,7 +227,8 @@ class MainWindow(QMainWindow):
             limit=self._settings["station_limit"],
             on_result=on_loaded,
             on_error=lambda e: self._station_list.set_error(
-                "Could not load stations — check your connection"
+                "Could not load stations — check your connection",
+                on_retry=lambda: self.load_top_stations(),
             ),
         )
 
@@ -266,7 +267,8 @@ class MainWindow(QMainWindow):
                 uuids,
                 on_result=self._station_list.set_stations,
                 on_error=lambda e: self._station_list.set_error(
-                    "Could not load favourites — check your connection"
+                    "Could not load favourites — check your connection",
+                    on_retry=lambda: self._switch_view("favourites"),
                 ),
             )
         elif view == "recent":
@@ -281,13 +283,17 @@ class MainWindow(QMainWindow):
                     uuids,
                     on_result=_on_recent_loaded,
                     on_error=lambda e: self._station_list.set_error(
-                        "Could not load recent — check your connection"
+                        "Could not load recent — check your connection",
+                        on_retry=lambda: self._switch_view("recent"),
                     ),
                 )
             else:
                 self._station_list.set_stations([])
         else:
-            self._station_list.set_stations(self._top_stations)
+            if self._top_stations:
+                self._station_list.set_stations(self._top_stations)
+            else:
+                self.load_top_stations()
 
     def _on_station_play(self, station: dict):
         url = station.get("url_resolved", "")
@@ -355,7 +361,7 @@ class MainWindow(QMainWindow):
             )
 
     def _on_stream_error(self, msg: str):
-        print(f"radiox: stream error: {msg}", flush=True)
+        print(f"dyedfox-radio: stream error: {msg}", flush=True)
         self._now_playing.set_error()
         self._controls.set_playing(False)
         if self._tray:
@@ -434,7 +440,7 @@ class MainWindow(QMainWindow):
         self._api.search(
             words[0],
             on_result=_on_result,
-            on_error=lambda e: print(f"radiox: search error: {e}", flush=True),
+            on_error=lambda e: print(f"dyedfox-radio: search error: {e}", flush=True),
         )
 
     def _on_add_custom_station(self):

--- a/ui/station_list.py
+++ b/ui/station_list.py
@@ -417,6 +417,8 @@ class StationListWidget(QWidget):
         self._apply_filter()
         if len(text) >= 2:
             self.search_requested.emit(text)
+        elif not text:
+            self.search_requested.emit("")
 
     def _apply_filter(self):
         words = self._search_input.text().lower().split()

--- a/ui/station_list.py
+++ b/ui/station_list.py
@@ -29,6 +29,10 @@ class _WaveWidget(QWidget):
     def freeze(self):
         self._timer.stop()
 
+    def show_frozen(self):
+        self._timer.stop()
+        self.show()
+
     def stop(self):
         self._timer.stop()
         self.hide()
@@ -214,7 +218,14 @@ class StationRowWidget(QWidget):
         self.setPalette(p)
 
     def freeze_wave(self):
-        self._wave.freeze()
+        self.setAutoFillBackground(True)
+        p = self.palette()
+        highlight = QPalette().color(QPalette.ColorRole.Highlight)
+        highlight.setAlpha(40)
+        p.setColor(QPalette.ColorRole.Window, highlight)
+        self._favicon.hide()
+        self._wave.show_frozen()
+        self.setPalette(p)
 
     def update_favourite(self, is_fav: bool):
         if self._heart_btn is None:
@@ -260,6 +271,7 @@ class StationListWidget(QWidget):
         self._recent_uuids: list[str] = []
         self._row_widgets: dict[str, StationRowWidget] = {}
         self._playing_uuid: str | None = None
+        self._is_playing: bool = False
         self._pool = QThreadPool.globalInstance()
 
         layout = QVBoxLayout(self)
@@ -282,11 +294,35 @@ class StationListWidget(QWidget):
         self._list.setSpacing(0)
         layout.addWidget(self._list)
 
+        self._error_widget = QWidget()
+        self._error_widget.hide()
+        error_layout = QVBoxLayout(self._error_widget)
+        error_layout.setSpacing(8)
+
         self._error_label = QLabel()
         self._error_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self._error_label.setWordWrap(True)
-        self._error_label.hide()
-        layout.addWidget(self._error_label)
+        error_layout.addWidget(self._error_label)
+
+        self._error_hint = QLabel("This may be a temporary server-side issue.")
+        self._error_hint.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self._error_hint.setEnabled(False)
+        error_layout.addWidget(self._error_hint)
+
+        self._retry_callback = None
+        self._retry_btn = QPushButton("Retry")
+        self._retry_btn.setFixedWidth(80)
+        self._retry_btn.clicked.connect(lambda: self._retry_callback and self._retry_callback())
+        self._retry_btn.hide()
+        retry_row = QWidget()
+        retry_row_layout = QHBoxLayout(retry_row)
+        retry_row_layout.setContentsMargins(0, 0, 0, 0)
+        retry_row_layout.addStretch()
+        retry_row_layout.addWidget(self._retry_btn)
+        retry_row_layout.addStretch()
+        error_layout.addWidget(retry_row)
+
+        layout.addWidget(self._error_widget)
 
         self._search_timer = QTimer(self)
         self._search_timer.setSingleShot(True)
@@ -294,7 +330,7 @@ class StationListWidget(QWidget):
         self._search_input.textChanged.connect(lambda: self._search_timer.start(350))
 
     def set_stations(self, stations: list[dict], deletable: bool = False):
-        self._error_label.hide()
+        self._error_widget.hide()
         self._list.show()
         self._list.clear()
         self._row_widgets.clear()
@@ -324,14 +360,19 @@ class StationListWidget(QWidget):
                 self._pool.start(loader)
 
         if self._playing_uuid and self._playing_uuid in self._row_widgets:
-            self._row_widgets[self._playing_uuid].set_playing(True)
+            if self._is_playing:
+                self._row_widgets[self._playing_uuid].set_playing(True)
+            else:
+                self._row_widgets[self._playing_uuid].freeze_wave()
 
         self._apply_filter()
 
-    def set_error(self, message: str):
+    def set_error(self, message: str, on_retry=None):
         self._list.hide()
         self._error_label.setText(message)
-        self._error_label.show()
+        self._retry_callback = on_retry
+        self._retry_btn.setVisible(on_retry is not None)
+        self._error_widget.show()
 
     def set_view(self, view: str, fav_uuids: set[str], recent_uuids: list[str]):
         self._current_view = view
@@ -343,14 +384,17 @@ class StationListWidget(QWidget):
         if self._playing_uuid and self._playing_uuid in self._row_widgets:
             self._row_widgets[self._playing_uuid].set_playing(False)
         self._playing_uuid = uuid
+        self._is_playing = True
         if uuid in self._row_widgets:
             self._row_widgets[uuid].set_playing(True)
 
     def mark_stopped(self):
+        self._is_playing = False
         if self._playing_uuid and self._playing_uuid in self._row_widgets:
             self._row_widgets[self._playing_uuid].freeze_wave()
 
     def mark_resumed(self):
+        self._is_playing = True
         if self._playing_uuid and self._playing_uuid in self._row_widgets:
             self._row_widgets[self._playing_uuid].set_playing(True)
 

--- a/ui/station_list.py
+++ b/ui/station_list.py
@@ -272,6 +272,7 @@ class StationListWidget(QWidget):
         self._row_widgets: dict[str, StationRowWidget] = {}
         self._playing_uuid: str | None = None
         self._is_playing: bool = False
+        self._favicon_cache: dict[str, bytes] = {}
         self._pool = QThreadPool.globalInstance()
 
         layout = QVBoxLayout(self)
@@ -355,9 +356,12 @@ class StationListWidget(QWidget):
 
             favicon_url = station.get("favicon", "")
             if favicon_url:
-                loader = _FaviconLoader(uuid, favicon_url)
-                loader.signals.loaded.connect(self._on_favicon_loaded)
-                self._pool.start(loader)
+                if uuid in self._favicon_cache:
+                    row.set_favicon(self._favicon_cache[uuid])
+                else:
+                    loader = _FaviconLoader(uuid, favicon_url)
+                    loader.signals.loaded.connect(self._on_favicon_loaded)
+                    self._pool.start(loader)
 
         if self._playing_uuid and self._playing_uuid in self._row_widgets:
             if self._is_playing:
@@ -409,6 +413,7 @@ class StationListWidget(QWidget):
         self.station_play_requested.emit(station)
 
     def _on_favicon_loaded(self, uuid: str, data: bytes):
+        self._favicon_cache[uuid] = data
         if uuid in self._row_widgets:
             self._row_widgets[uuid].set_favicon(data)
 


### PR DESCRIPTION
- Fixed equalizer freeze not persisting when switching between views
- Added automatic retry on API failures - transient server issues are now handled silently before showing an error
- Added Retry button and a note that errors may be caused by a temporary server-side issue (recently noticed with radio-browser.info)
- Migrated user config directory from ~/.config/radiox (legacy) to ~/.config/dyedfox-radio -existing data is preserved automatically
- Cache station favicons in memory — no re-download when switching views or clearing search