### PR TITLE
Trim leading/trailing whitespace from station names

### DIFF
--- a/ui/info_panel.py
+++ b/ui/info_panel.py
@@ -126,7 +126,7 @@ class InfoPanel(QWidget):
 
     def set_station(self, station: dict, is_favourite: bool = False):
         self._uuid = station.get("stationuuid", "")
-        self._station_name = station.get("name", "")
+        self._station_name = station.get("name", "").strip()
         self._homepage_url = station.get("homepage", "")
         self._name.setText(self._station_name)
         self._country.setText(station.get("country", ""))

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -320,7 +320,7 @@ class MainWindow(QMainWindow):
         self._current_station = station
         self._last_title = ""
         self._backend.play(url)
-        self._now_playing.set_station(station.get("name", ""))
+        self._now_playing.set_station(station.get("name", "").strip())
         self._now_playing.clear_song()
         self._info_panel.set_station(station, self._favourites.is_favourite(station.get("stationuuid", "")))
         self._station_list.mark_playing(station.get("stationuuid", ""))

--- a/ui/station_list.py
+++ b/ui/station_list.py
@@ -168,7 +168,7 @@ class StationRowWidget(QWidget):
         text_layout.setContentsMargins(0, 0, 0, 0)
         text_layout.setSpacing(1)
 
-        name_label = _ElidedLabel(station.get("name", ""))
+        name_label = _ElidedLabel(station.get("name", "").strip())
         f = name_label.font()
         f.setBold(True)
         name_label.setFont(f)

--- a/ui/station_list.py
+++ b/ui/station_list.py
@@ -562,7 +562,7 @@ class StationListWidget(QWidget):
 
         def sort_key(s: dict):
             v = s.get(field, "")
-            return v.lower() if isinstance(v, str) else (v or 0)
+            return v.strip().lower() if isinstance(v, str) else (v or 0)
 
         return sorted(self._stations_raw, key=sort_key, reverse=not ascending)
 


### PR DESCRIPTION
Station names from the API can sometimes have leading or trailing spaces. This PR fixes that in two ways: