### PR TITLE
Fix SIGSEGV during station list rebuild

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Yaroslav Krytsun <slavko7 at gmail dot com>
 pkgname=dyedfox-radio
-pkgver=0.4.0
+pkgver=0.4.1
 pkgrel=1
 pkgdesc="Desktop internet radio player for KDE Plasma"
 arch=('any')

--- a/ui/about_dialog.py
+++ b/ui/about_dialog.py
@@ -31,7 +31,7 @@ class AboutDialog(QDialog):
         name.setFont(f)
         layout.addWidget(name)
 
-        version = QLabel("Version 0.4.0")
+        version = QLabel("Version 0.4.1")
         version.setAlignment(Qt.AlignmentFlag.AlignCenter)
         version.setEnabled(False)
         layout.addWidget(version)

--- a/ui/station_list.py
+++ b/ui/station_list.py
@@ -499,7 +499,9 @@ class StationListWidget(QWidget):
 
         self._error_widget.hide()
         self._list.show()
+        self._list.setUpdatesEnabled(False)
         self._list.clear()
+        self._list.setUpdatesEnabled(True)
         self._row_widgets.clear()
         self._item_map.clear()
 


### PR DESCRIPTION
Fix SIGSEGV during station list rebuild
Fix crash: suppress paint events during list clear to prevent Breeze from styling destroyed widgets