### PR TITLE
fix: follow Bluetooth headphones without restarting the app

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Yaroslav Krytsun <slavko7 at gmail dot com>
 pkgname=dyedfox-radio
-pkgver=0.4.2
+pkgver=0.4.3
 pkgrel=1
 pkgdesc="Desktop internet radio player for KDE Plasma"
 arch=('any')

--- a/player/backend.py
+++ b/player/backend.py
@@ -19,6 +19,14 @@ class GStreamerBackend(QObject):
                 "Failed to create GStreamer playbin element. "
                 "Make sure gstreamer and gst-plugins-good are installed."
             )
+
+        # pulsesink (also works via PipeWire's PA layer) follows the default
+        # sink dynamically, so Bluetooth headphones picked up mid-session work
+        # without restarting. autoaudiosink locks to the device at play time.
+        audio_sink = Gst.ElementFactory.make("pulsesink", "audio_sink")
+        if audio_sink is not None:
+            self._player.set_property("audio-sink", audio_sink)
+
         self._bus = self._player.get_bus()
         self._last_url: str | None = None
 

--- a/ui/about_dialog.py
+++ b/ui/about_dialog.py
@@ -31,7 +31,7 @@ class AboutDialog(QDialog):
         name.setFont(f)
         layout.addWidget(name)
 
-        version = QLabel("Version 0.4.2")
+        version = QLabel("Version 0.4.3")
         version.setAlignment(Qt.AlignmentFlag.AlignCenter)
         version.setEnabled(False)
         layout.addWidget(version)


### PR DESCRIPTION
Bug fix: Audio now follows Bluetooth headphones without restarting the app.

Previously, connecting Bluetooth headphones mid-session had no effect - the stream continued playing through the speaker that was active when playback started. This was caused by GStreamer's autoaudiosink locking to the audio device at play time. The app now uses pulsesink instead, which stays connected to PulseAudio/PipeWire's routing layer and follows default-sink changes in real time, matching the behavior of other desktop apps.