### PR TITLE
Locked screen MPRIS fix

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Yaroslav Krytsun <slavko7 at gmail dot com>
 pkgname=dyedfox-radio
-pkgver=0.4.5
+pkgver=0.4.6
 pkgrel=1
 pkgdesc="Desktop internet radio player for KDE Plasma"
 arch=('any')

--- a/player/mpris.py
+++ b/player/mpris.py
@@ -80,28 +80,30 @@ if _DBUS_OK:
                  "mpris:artUrl": dbus.String(art_url)},
                 signature="sv",
             )
-            playing = self._backend.is_playing
             has_url = self._backend.last_url is not None
             self.PropertiesChanged(
                 _PLAYER,
                 {
                     "Metadata": self._metadata,
                     "PlaybackStatus": self._status(),
-                    "CanPause": dbus.Boolean(playing),
-                    "CanPlay": dbus.Boolean(has_url and not playing),
-                    "CanStop": dbus.Boolean(playing),
+                    # Per MPRIS spec these are capability flags, not state — keep
+                    # them true whenever a station is loaded so consumers like the
+                    # lock screen don't disable their controls. PlaybackStatus
+                    # alone tells them which icon (play/pause) to show.
+                    "CanPause": dbus.Boolean(has_url),
+                    "CanPlay": dbus.Boolean(has_url),
+                    "CanStop": dbus.Boolean(has_url),
                 },
                 [],
             )
 
         def push_status(self):
-            playing = self._backend.is_playing
             has_url = self._backend.last_url is not None
             self.PropertiesChanged(_PLAYER, {
                 "PlaybackStatus": self._status(),
-                "CanPause": dbus.Boolean(playing),
-                "CanPlay": dbus.Boolean(has_url and not playing),
-                "CanStop": dbus.Boolean(playing),
+                "CanPause": dbus.Boolean(has_url),
+                "CanPlay": dbus.Boolean(has_url),
+                "CanStop": dbus.Boolean(has_url),
             }, [])
 
         def _status(self) -> dbus.String:
@@ -119,15 +121,14 @@ if _DBUS_OK:
                     "SupportedMimeTypes": dbus.Array([], signature="s"),
                 }
             if iface == _PLAYER:
-                playing = self._backend.is_playing
                 has_url = self._backend.last_url is not None
                 return {
                     "PlaybackStatus": self._status(),
                     "CanGoNext": dbus.Boolean(False),
                     "CanGoPrevious": dbus.Boolean(False),
-                    "CanPause": dbus.Boolean(playing),
-                    "CanPlay": dbus.Boolean(has_url and not playing),
-                    "CanStop": dbus.Boolean(playing),
+                    "CanPause": dbus.Boolean(has_url),
+                    "CanPlay": dbus.Boolean(has_url),
+                    "CanStop": dbus.Boolean(has_url),
                     "CanSeek": dbus.Boolean(False),
                     "CanControl": dbus.Boolean(True),
                     "Metadata": self._metadata,

--- a/ui/about_dialog.py
+++ b/ui/about_dialog.py
@@ -31,7 +31,7 @@ class AboutDialog(QDialog):
         name.setFont(f)
         layout.addWidget(name)
 
-        version = QLabel("Version 0.4.5")
+        version = QLabel("Version 0.4.6")
         version.setAlignment(Qt.AlignmentFlag.AlignCenter)
         version.setEnabled(False)
         layout.addWidget(version)


### PR DESCRIPTION
Fixes
- Lock-screen media controls now work. Play/Pause stays active on the lock screen (and other MPRIS consumers) whenever a station is loaded - previously the buttons were greyed out. Fixed by reporting CanPlay/CanPause/CanStop as capability flags per the MPRIS spec instead of tying them to playback state.