### PR TITLE
Fewer dead stations in browse lists

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Yaroslav Krytsun <slavko7 at gmail dot com>
 pkgname=dyedfox-radio
-pkgver=0.4.6
+pkgver=0.4.7
 pkgrel=1
 pkgdesc="Desktop internet radio player for KDE Plasma"
 arch=('any')

--- a/api/radio_browser.py
+++ b/api/radio_browser.py
@@ -93,7 +93,7 @@ class RadioBrowserClient:
         self._pool = QThreadPool.globalInstance()
 
     def top_stations(self, limit: int = 100, on_result=None, on_error=None):
-        self._run(f"{BASE_URL}/stations/topvote/{limit}", {}, on_result, on_error)
+        self._run(f"{BASE_URL}/stations/topvote/{limit}", {"hidebroken": "true"}, on_result, on_error)
 
     def search(self, name: str = "", country: str = "", tag: str = "", language: str = "", limit: int = 100, on_result=None, on_error=None):
         params: dict = {"limit": limit, "hidebroken": "true"}
@@ -111,7 +111,9 @@ class RadioBrowserClient:
         self._run(f"{BASE_URL}/stations/bytag/{tag}", {}, on_result, on_error)
 
     def new_stations(self, limit: int = 100, on_result=None, on_error=None):
-        self._run(f"{BASE_URL}/stations/lastchange/{limit}", {}, on_result, on_error)
+        # lastchange returns the most recently added/edited stations, many of
+        # which are unverified — hidebroken drops the ones already flagged dead.
+        self._run(f"{BASE_URL}/stations/lastchange/{limit}", {"hidebroken": "true"}, on_result, on_error)
 
     def random_stations(self, limit: int = 100, on_result=None, on_error=None):
         self._run(f"{BASE_URL}/stations/search", {"order": "random", "limit": limit, "hidebroken": "true"}, on_result, on_error)

--- a/ui/about_dialog.py
+++ b/ui/about_dialog.py
@@ -31,7 +31,7 @@ class AboutDialog(QDialog):
         name.setFont(f)
         layout.addWidget(name)
 
-        version = QLabel("Version 0.4.6")
+        version = QLabel("Version 0.4.7")
         version.setAlignment(Qt.AlignmentFlag.AlignCenter)
         version.setEnabled(False)
         layout.addWidget(version)


### PR DESCRIPTION
Fixes
- Fewer dead stations in browse lists. The New Stations and All Stations views now filter out stations that radio-browser has already flagged as broken, so far more entries play on the first click. (Random, Trending, and Search were already filtered.) Favourites and Recent intentionally still show everything you've saved.