### PR TITLE
Fixed a lot of crashes

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Yaroslav Krytsun <slavko7 at gmail dot com>
 pkgname=dyedfox-radio
-pkgver=0.4.7
+pkgver=0.4.8
 pkgrel=1
 pkgdesc="Desktop internet radio player for KDE Plasma"
 arch=('any')

--- a/player/backend.py
+++ b/player/backend.py
@@ -1,3 +1,5 @@
+import threading
+
 import gi
 gi.require_version('Gst', '1.0')
 from gi.repository import Gst
@@ -46,6 +48,19 @@ class GStreamerBackend(QObject):
         self._retry_count = 0
         self._reconnecting = False
 
+        # Pipeline state changes block: set_state(NULL) joins the streaming
+        # thread, which can stall for seconds on a slow/half-open network socket.
+        # Running that on the GUI thread freezes the window, so a dedicated worker
+        # performs every transition. PyGObject releases the GIL during the C call,
+        # so the UI stays responsive. Only the most recent request matters
+        # (latest-wins), which collapses a burst of clicks into one teardown.
+        self._cmd: tuple[str, str | None] | None = None
+        self._cmd_lock = threading.Lock()
+        self._cmd_event = threading.Event()
+        self._worker_stop = False
+        self._worker = threading.Thread(target=self._worker_loop, daemon=True)
+        self._worker.start()
+
         self._reconnect_timer = QTimer(self)
         self._reconnect_timer.setSingleShot(True)
         self._reconnect_timer.timeout.connect(self._attempt_reconnect)
@@ -58,16 +73,41 @@ class GStreamerBackend(QObject):
         self._timer.timeout.connect(self._poll_bus)
         self._timer.start(200)
 
+    def _submit(self, action: str, url: str | None = None):
+        # Hand a transition to the worker thread; latest request wins.
+        with self._cmd_lock:
+            self._cmd = (action, url)
+            self._cmd_event.set()
+
+    def _worker_loop(self):
+        while True:
+            self._cmd_event.wait()
+            if self._worker_stop:
+                self._player.set_state(Gst.State.NULL)
+                return
+            with self._cmd_lock:
+                cmd = self._cmd
+                self._cmd = None
+                self._cmd_event.clear()
+            if cmd is None:
+                continue
+            action, url = cmd
+            if action == "play":
+                # Tear the old stream down, then point playbin at the new URL.
+                self._player.set_state(Gst.State.NULL)
+                self._player.set_property("uri", url)
+                self._player.set_state(Gst.State.PLAYING)
+            elif action == "stop":
+                self._player.set_state(Gst.State.NULL)
+
     def play(self, url: str):
         self._reconnect_timer.stop()
         self._stable_timer.stop()
         self._retry_count = 0
         self._reconnecting = False
         self._playing = True
-        self._player.set_state(Gst.State.NULL)
-        self._player.set_property("uri", url)
         self._last_url = url
-        self._player.set_state(Gst.State.PLAYING)
+        self._submit("play", url)
         self.playback_started.emit()
 
     def play_last(self):
@@ -80,19 +120,22 @@ class GStreamerBackend(QObject):
         self._retry_count = 0
         self._reconnecting = False
         self._playing = False
-        self._player.set_state(Gst.State.NULL)
+        self._submit("stop")
         self.playback_stopped.emit()
 
     def shutdown(self):
         # Full teardown for app exit: stop every timer so nothing fires during
-        # shutdown, then drop the pipeline to NULL to release GStreamer's
-        # streaming threads before the interpreter finalizes.
+        # shutdown, then tell the worker to drop the pipeline to NULL and exit.
+        # Join briefly; if a transition is wedged on the network, the os._exit
+        # backstop in main() guarantees the process still dies.
         self._timer.stop()
         self._reconnect_timer.stop()
         self._stable_timer.stop()
         self._playing = False
         self._reconnecting = False
-        self._player.set_state(Gst.State.NULL)
+        self._worker_stop = True
+        self._cmd_event.set()
+        self._worker.join(timeout=2)
 
     def set_volume(self, value: int):
         self._player.set_property("volume", max(0, min(100, value)) / 100.0)
@@ -121,7 +164,6 @@ class GStreamerBackend(QObject):
         # blip, or an audio device switch (e.g. Bluetooth). Reconnect with
         # backoff before giving up so transient drops recover on their own.
         self._stable_timer.stop()
-        self._player.set_state(Gst.State.NULL)
         if self._last_url and self._retry_count < self._MAX_RETRIES:
             delay = self._RETRY_DELAYS_MS[self._retry_count]
             self._retry_count += 1
@@ -129,6 +171,7 @@ class GStreamerBackend(QObject):
             self.reconnecting.emit(self._retry_count)
             self._reconnect_timer.start(delay)
         else:
+            self._submit("stop")
             self._retry_count = 0
             self._reconnecting = False
             self._playing = False
@@ -138,9 +181,8 @@ class GStreamerBackend(QObject):
     def _attempt_reconnect(self):
         if not self._last_url:
             return
-        self._player.set_state(Gst.State.NULL)
-        self._player.set_property("uri", self._last_url)
-        self._player.set_state(Gst.State.PLAYING)
+        # Teardown + restart happens on the worker thread (see _worker_loop).
+        self._submit("play", self._last_url)
         # Retry counter resets only once playback has been stable for a while
         # (see _mark_stable), not the moment we connect.
 

--- a/ui/about_dialog.py
+++ b/ui/about_dialog.py
@@ -31,7 +31,7 @@ class AboutDialog(QDialog):
         name.setFont(f)
         layout.addWidget(name)
 
-        version = QLabel("Version 0.4.7")
+        version = QLabel("Version 0.4.8")
         version.setAlignment(Qt.AlignmentFlag.AlignCenter)
         version.setEnabled(False)
         layout.addWidget(version)

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -4,7 +4,7 @@ from PyQt6.QtWidgets import (
 )
 from pathlib import Path
 import subprocess
-from PyQt6.QtCore import Qt, QSize, QEvent, QThreadPool
+from PyQt6.QtCore import Qt, QSize, QEvent, QThreadPool, QTimer
 from PyQt6.QtGui import QIcon, QShortcut, QKeySequence, QPixmap
 
 _NOTIF_ICON_PATH = Path.home() / ".config" / "dyedfox-radio" / "notif_icon.png"
@@ -50,9 +50,18 @@ class MainWindow(QMainWindow):
         self._last_title: str = ""
         self._tray = None
         self._mpris = None
-        self._panel_favicon_loader = None
+        self._panel_favicon_loaders: set = set()  # keep-alive until run() finishes
         self._current_favicon: QIcon | None = None
         self._pending_notification: tuple[str, str] | None = None  # (station, title)
+
+        # Clicking a station calls GStreamer set_state(NULL), which blocks the GUI
+        # thread until the stream tears down. Rapid clicks stack these teardowns
+        # and freeze the UI, so debounce: only the final selection actually plays.
+        self._pending_play_station: dict | None = None
+        self._play_debounce = QTimer(self)
+        self._play_debounce.setSingleShot(True)
+        self._play_debounce.setInterval(250)
+        self._play_debounce.timeout.connect(self._start_pending_play)
 
         self.setWindowTitle("Dyedfox Radio")
         _icon = Path(__file__).parent.parent / "assets" / "icons" / "dyedfox-radio.png"
@@ -375,6 +384,19 @@ class MainWindow(QMainWindow):
         url = station.get("url_resolved", "")
         if not url:
             return
+        # Defer the actual play so a burst of clicks results in a single stream
+        # teardown/start instead of one blocking set_state(NULL) per click.
+        self._pending_play_station = station
+        self._play_debounce.start()
+
+    def _start_pending_play(self):
+        station = self._pending_play_station
+        self._pending_play_station = None
+        if not station:
+            return
+        url = station.get("url_resolved", "")
+        if not url:
+            return
         self._current_station = station
         self._last_title = ""
         self._backend.play(url)
@@ -394,7 +416,10 @@ class MainWindow(QMainWindow):
         from ui.station_list import _FaviconLoader
         loader = _FaviconLoader("panel", url)
         loader.signals.loaded.connect(self._on_panel_favicon_loaded)
-        self._panel_favicon_loader = loader  # prevent GC until signal fires
+        # Hold a reference until run() finishes; switching stations quickly would
+        # otherwise GC an in-flight loader and crash the pool (use-after-free).
+        loader.signals.finished.connect(self._panel_favicon_loaders.discard)
+        self._panel_favicon_loaders.add(loader)
         QThreadPool.globalInstance().start(loader)
 
     def _on_panel_favicon_loaded(self, _uuid: str, data: bytes):

--- a/ui/station_list.py
+++ b/ui/station_list.py
@@ -117,6 +117,7 @@ class _ElidedLabel(QLabel):
 
 class _FaviconSignals(QObject):
     loaded = pyqtSignal(str, bytes)  # uuid, raw bytes
+    finished = pyqtSignal(object)    # the loader itself, for keep-alive bookkeeping
 
 
 class _FaviconLoader(QRunnable):
@@ -137,6 +138,15 @@ class _FaviconLoader(QRunnable):
                     pass
         except Exception:
             pass
+        finally:
+            # autoDelete is False, so Python owns this QRunnable. The owner must
+            # keep a reference until run() has fully returned — dropping it while
+            # the pool still holds the runnable causes a use-after-free (SIGSEGV).
+            # Signal completion so the owner can release its reference safely.
+            try:
+                self.signals.finished.emit(self)
+            except RuntimeError:
+                pass
 
 
 class StationRowWidget(QWidget):
@@ -321,7 +331,10 @@ class StationListWidget(QWidget):
         self._is_playing: bool = False
         self._favicon_cache: dict[str, bytes] = {}
         self._pool = QThreadPool.globalInstance()
-        self._pending_favicon_loaders: list[_FaviconLoader] = []
+        # Keep-alive set for in-flight favicon loaders (autoDelete=False). A loader
+        # stays here until its run() finishes or we successfully cancel it before
+        # it starts; otherwise the pool could dereference a freed QRunnable.
+        self._active_loaders: set[_FaviconLoader] = set()
         self._build_gen: int = 0
         self._built_uuids: list[str] = []
         self._built_deletable: bool = False
@@ -486,10 +499,20 @@ class StationListWidget(QWidget):
 
     _BATCH_SIZE = 40
 
+    def _cancel_loaders(self):
+        # Cancel queued favicon loaders. tryTake removes those not yet started, so
+        # they will never run and are safe to release. Loaders already running keep
+        # their reference until their finished signal fires — releasing them now
+        # would let the pool touch freed memory (SIGSEGV).
+        for loader in list(self._active_loaders):
+            if self._pool.tryTake(loader):
+                self._active_loaders.discard(loader)
+
+    def _on_loader_finished(self, loader):
+        self._active_loaders.discard(loader)
+
     def _rebuild(self):
-        for loader in self._pending_favicon_loaders:
-            self._pool.tryTake(loader)
-        self._pending_favicon_loaders.clear()
+        self._cancel_loaders()
 
         sorted_stations = self._sorted_stations()
         self._built_uuids = [s.get("stationuuid", "") for s in sorted_stations]
@@ -544,7 +567,8 @@ class StationListWidget(QWidget):
             else:
                 loader = _FaviconLoader(uuid, favicon_url)
                 loader.signals.loaded.connect(self._on_favicon_loaded)
-                self._pending_favicon_loaders.append(loader)
+                loader.signals.finished.connect(self._on_loader_finished)
+                self._active_loaders.add(loader)
                 self._pool.start(loader)
 
     def _finish_rebuild(self):
@@ -605,9 +629,7 @@ class StationListWidget(QWidget):
                 self._list.scrollToItem(item, self._list.ScrollHint.PositionAtCenter)
 
     def cancel_pending_favicons(self):
-        for loader in self._pending_favicon_loaders:
-            self._pool.tryTake(loader)
-        self._pending_favicon_loaders.clear()
+        self._cancel_loaders()
 
     def start_loading(self):
         self._spinner.start()


### PR DESCRIPTION
Fixed

- Fixed a crash when switching stations quickly. Rapidly clicking through stations or browse views could segfault the app. Station artwork was loaded in background threads whose lifetime wasn't held correctly, so a load that was cancelled mid-flight could be freed while still in use. Artwork loaders are now kept alive until they finish.
- Fixed the window freezing on rapid station switching. Starting a stream briefly blocked the interface while the previous stream was torn down — a burst of clicks could stack these and lock the window ("Not Responding"). Stream start/stop now happens off the interface thread, so the app stays responsive no matter how fast you tap. Rapid clicks also collapse into a single switch, so only the station you land on starts playing.