### PR TITLE
Add Nix flake and install instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Inspired by [Shortwave](https://github.com/maunalinux/shortwave), with a native 
 - [Features](#features)
 - [Keyboard Shortcuts](#keyboard-shortcuts)
 - [Install on Arch Linux (AUR)](#install-on-arch-linux-aur)
+- [Install on NixOS](#install-on-nixos)
 - [Build from source (PKGBUILD)](#build-from-source-pkgbuild)
 - [Install on other Linux distros](#install-on-other-linux-distros)
 - [Manual installation](#manual-installation)
@@ -66,6 +67,58 @@ Or manually:
 git clone https://aur.archlinux.org/dyedfox-radio.git
 cd dyedfox-radio
 makepkg -si
+```
+
+## Install on NixOS
+
+### Channels
+
+You can import the package using [`flake-compat`](https://github.com/edolstra/flake-compat) in your `configuration.nix`:
+
+```nix
+let
+  flakeCompat = import (builtins.fetchTarball {
+    url = "https://github.com/edolstra/flake-compat/archive/master.tar.gz";
+    # sha256 = "..."; # Optional: obtain with `nix-prefetch-url --unpack <url>`
+  });
+  dyedfoxRadio = flakeCompat {
+    src = builtins.fetchTarball {
+      url = "https://github.com/dyedfox/dyedfox-radio/archive/main.tar.gz";
+      # sha256 = "..."; # Optional: obtain with `nix-prefetch-url --unpack <url>`
+    };
+  };
+in {
+  environment.systemPackages = [
+    dyedfoxRadio.defaultNix.packages.${pkgs.system}.default
+  ];
+}
+```
+
+### Flakes
+
+Add `dyedfox-radio` to your `flake.nix` inputs:
+
+```nix
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    dyedfox-radio.url = "github:dyedfox/dyedfox-radio";
+  };
+
+  outputs = { self, nixpkgs, dyedfox-radio, ... }@inputs: {
+    nixosConfigurations.<your-hostname> = nixpkgs.lib.nixosSystem {
+      # ...
+      modules = [
+        ./configuration.nix
+        {
+          environment.systemPackages = [
+            dyedfox-radio.packages.${pkgs.system}.default
+          ];
+        }
+      ];
+    };
+  };
+}
 ```
 
 ## Build from source (PKGBUILD)

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1786514691,
+        "narHash": "sha256-9dkt1i5JNbEfPb+EjLcSDNs8zqEHQ/1JlSaKgj0SBAg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "867dcbc30bafe3c862ef88620f2e7a109d7d3be5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,97 @@
+{
+  description = "Dyedfox Radio - Desktop internet radio player for KDE Plasma";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs = { self, nixpkgs }:
+    let
+      supportedSystems = [ "x86_64-linux" "aarch64-linux" ];
+      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+    in {
+      packages = forAllSystems (system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+        in {
+          default = pkgs.python3Packages.buildPythonApplication {
+            pname = "dyedfox-radio";
+            version = "unstable-${self.shortRev or "dirty"}";
+
+            src = self;
+
+            format = "other";
+
+            nativeBuildInputs = with pkgs; [
+              qt6.wrapQtAppsHook
+              wrapGAppsNoGuiHook
+              qt6.qttools
+              gobject-introspection
+            ];
+
+            buildInputs = with pkgs; [
+              qt6.qtwayland
+              qt6.qtbase
+              gst_all_1.gstreamer
+              gst_all_1.gst-plugins-base
+              gst_all_1.gst-plugins-good
+              gst_all_1.gst-plugins-bad
+              gst_all_1.gst-libav
+            ];
+
+            dependencies = with pkgs.python3Packages; [
+              pyqt6
+              pyqt6-sip
+              requests
+              dbus-python
+              pygobject3
+            ];
+
+            dontWrapQtApps = true;
+            dontWrapGApps = true;
+
+            buildPhase = ''
+              runHook preBuild
+              
+              lrelease translations/*.ts
+              
+              runHook postBuild
+            '';
+
+            installPhase = ''
+              runHook preInstall
+
+              mkdir -p $out/bin
+              mkdir -p $out/lib/dyedfox-radio/translations
+              mkdir -p $out/share/applications
+              mkdir -p $out/share/icons/hicolor/256x256/apps
+              mkdir -p $out/share/icons/hicolor/scalable/apps
+              mkdir -p $out/share/licenses/dyedfox-radio
+
+              cp -r api data player tray ui assets main.py $out/lib/dyedfox-radio/
+              cp translations/*.qm $out/lib/dyedfox-radio/translations/
+              
+              cp dyedfox-radio.desktop $out/share/applications/
+              cp assets/icons/dyedfox-radio.png $out/share/icons/hicolor/256x256/apps/
+              cp assets/icons/dyedfox-radio-tray.svg $out/share/icons/hicolor/scalable/apps/
+              cp LICENSE $out/share/licenses/dyedfox-radio/
+
+              echo "#!${pkgs.python3.interpreter}" > $out/bin/dyedfox-radio
+              echo "import sys" >> $out/bin/dyedfox-radio
+              echo "import runpy" >> $out/bin/dyedfox-radio
+              echo "sys.path.insert(0, \"$out/lib/dyedfox-radio\")" >> $out/bin/dyedfox-radio
+              echo "runpy.run_path(\"$out/lib/dyedfox-radio/main.py\", run_name=\"__main__\")" >> $out/bin/dyedfox-radio
+              chmod +x $out/bin/dyedfox-radio
+
+              runHook postInstall
+            '';
+
+            preFixup = ''
+              makeWrapperArgs+=("''${qtWrapperArgs[@]}")
+              makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+            '';
+          };
+        }
+      );
+    };
+}


### PR DESCRIPTION
This PR adds a Nix flake (`flake.nix` and `flake.lock`) and updates `README.md` with installation examples for Nix flakes and channels.